### PR TITLE
Deploy climsim production runs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
             echo prune=false >> $GITHUB_ENV
           fi
       - name: "Deploy recipes"
-        uses: "pangeo-forge/deploy-recipe-action@skip-deploy-if-no-labels"
+        uses: "pangeo-forge/deploy-recipe-action@assorted-fixes"
         with:
           select_recipe_by_label: true
           pangeo_forge_runner_config: >

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
             echo prune=false >> $GITHUB_ENV
           fi
       - name: "Deploy recipes"
-        uses: "pangeo-forge/deploy-recipe-action@29cd2736f71eb00addb540632eb286e90da2d17f"
+        uses: "pangeo-forge/deploy-recipe-action@6eab39f26d1d2ee63dc17f69c2fd582d605d2ad6"
         with:
           select_recipe_by_label: true
           pangeo_forge_runner_config: >

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
             echo prune=false >> $GITHUB_ENV
           fi
       - name: "Deploy recipes"
-        uses: "pangeo-forge/deploy-recipe-action@assorted-fixes"
+        uses: "pangeo-forge/deploy-recipe-action@881c679b2cfac6d0d7e7f1e57c1e70d80508b84a"
         with:
           select_recipe_by_label: true
           pangeo_forge_runner_config: >

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
             echo prune=false >> $GITHUB_ENV
           fi
       - name: "Deploy recipes"
-        uses: "pangeo-forge/deploy-recipe-action@6eab39f26d1d2ee63dc17f69c2fd582d605d2ad6"
+        uses: "pangeo-forge/deploy-recipe-action@v0.1"
         with:
           select_recipe_by_label: true
           pangeo_forge_runner_config: >

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
             echo prune=false >> $GITHUB_ENV
           fi
       - name: "Deploy recipes"
-        uses: "pangeo-forge/deploy-recipe-action@881c679b2cfac6d0d7e7f1e57c1e70d80508b84a"
+        uses: "pangeo-forge/deploy-recipe-action@29cd2736f71eb00addb540632eb286e90da2d17f"
         with:
           select_recipe_by_label: true
           pangeo_forge_runner_config: >

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -3,4 +3,4 @@
 # https://github.com/leap-stc/data-management/pull/33 (see PR discussion for details).
 # once a `0.10.1` release of `pangeo-forge-recipes` is available that includes this fix, we should
 # install from that release instead.
-git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@a22e6aafc938be05809b55d9a3fced5598e71698
+git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@6eab39f26d1d2ee63dc17f69c2fd582d605d2ad6

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -3,4 +3,4 @@
 # https://github.com/leap-stc/data-management/pull/33 (see PR discussion for details).
 # once a `0.10.1` release of `pangeo-forge-recipes` is available that includes this fix, we should
 # install from that release instead.
-git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@6eab39f26d1d2ee63dc17f69c2fd582d605d2ad6
+git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@a22e6aafc938be05809b55d9a3fced5598e71698

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,1 +1,6 @@
+# this commit represents the point at which https://github.com/pangeo-forge/pangeo-forge-recipes/pull/548
+# was merged into `main`. we are installing from here to unblock the climsim `mli` recipe added in
+# https://github.com/leap-stc/data-management/pull/33 (see PR discussion for details).
+# once a `0.10.1` release of `pangeo-forge-recipes` is available that includes this fix, we should
+# install from that release instead.
 git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@a22e6aafc938be05809b55d9a3fced5598e71698


### PR DESCRIPTION
PR begun as integration testing for fixes made in https://github.com/pangeo-forge/deploy-recipe-action/pull/13.

With those fixes implemented, merging this should deploy production runs of climsim (which were not deployed on merge of #33).