### PR TITLE
Limit caching concurrency for climsim recipe

### DIFF
--- a/feedstock/climsim.py
+++ b/feedstock/climsim.py
@@ -149,7 +149,7 @@ class OpenAndPreprocess(beam.PTransform):
             # FIXME: rate limiting on caching step is probably required to get this to run
             # end-to-end, without globally capping workers at a low value for all stages,
             # see discussion in: https://github.com/leap-stc/data-management/issues/36.
-            | OpenURLWithFSSpec()
+            | OpenURLWithFSSpec(max_concurrency=20)
             | OpenWithXarray(
                 # FIXME: Get files to open without `copy_to_local=True`
                 # Related: what is the filetype? Looks like netcdf3, but for some reason

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -3,4 +3,7 @@
 # https://github.com/leap-stc/data-management/pull/33 (see PR discussion for details).
 # once a `0.10.1` release of `pangeo-forge-recipes` is available that includes this fix, we should
 # install from that release instead.
-git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@a22e6aafc938be05809b55d9a3fced5598e71698
+# git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@a22e6aafc938be05809b55d9a3fced5598e71698
+
+# temporarily point to this PR branch to evaluate it in a real world use case
+git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@limit-concurrency


### PR DESCRIPTION
Installs pangeo-forge-recipes from https://github.com/pangeo-forge/pangeo-forge-recipes/pull/557 and sets the `max_concurrency` arg added by that PR to limit the number of simultaneous requests to Hugging Face. Hopefully a solution for #36.



