### PR TITLE
ClimSim: decrease target chunks, increase concurrency

### DIFF
--- a/feedstock/climsim.py
+++ b/feedstock/climsim.py
@@ -146,10 +146,7 @@ class OpenAndPreprocess(beam.PTransform):
     def expand(self, pcoll: beam.PCollection) -> beam.PCollection:
         return (
             pcoll
-            # FIXME: rate limiting on caching step is probably required to get this to run
-            # end-to-end, without globally capping workers at a low value for all stages,
-            # see discussion in: https://github.com/leap-stc/data-management/issues/36.
-            | OpenURLWithFSSpec(max_concurrency=20)
+            | OpenURLWithFSSpec(max_concurrency=30)
             | OpenWithXarray(
                 # FIXME: Get files to open without `copy_to_local=True`
                 # Related: what is the filetype? Looks like netcdf3, but for some reason
@@ -171,7 +168,7 @@ climsim_highres_mli = (
     | OpenAndPreprocess()
     | StoreToZarr(
         store_name='climsim-highres-mli.zarr',
-        target_chunks={'time': 20},
+        target_chunks={'time': 2},
         combine_dims=mli_pattern.combine_dim_keys,
     )
 )
@@ -183,7 +180,7 @@ climsim_highres_mlo = (
     | OpenAndPreprocess()
     | StoreToZarr(
         store_name='climsim-highres-mlo.zarr',
-        target_chunks={'time': 20},
+        target_chunks={'time': 2},
         combine_dims=mlo_pattern.combine_dim_keys,
     )
 )

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,9 +1,6 @@
-# this commit represents the point at which https://github.com/pangeo-forge/pangeo-forge-recipes/pull/548
+# this commit represents the point at which https://github.com/pangeo-forge/pangeo-forge-recipes/pull/557
 # was merged into `main`. we are installing from here to unblock the climsim `mli` recipe added in
 # https://github.com/leap-stc/data-management/pull/33 (see PR discussion for details).
 # once a `0.10.1` release of `pangeo-forge-recipes` is available that includes this fix, we should
 # install from that release instead.
-# git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@a22e6aafc938be05809b55d9a3fced5598e71698
-
-# temporarily point to this PR branch to evaluate it in a real world use case
-git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@limit-concurrency
+git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@2739f2264ec385eadd3c73226fb85f5cdbf32a1a


### PR DESCRIPTION
The climsim recipes failed on dataflow with OOM-style errors, which made me realize that the target chunks were too big (by a factor of 10 🤭 ). This PR reduces the chunk size. Also, I think I might be able to get away with slightly more caching concurrency, so trying that here.